### PR TITLE
Genre + fiction/nonfiction metadata enrichment (BOOK-11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@
 .env
 .DS_Store
 db/*.sqlite3
+db/*.sqlite3-*
 .idea
 /coverage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,10 @@ Metrics/MethodLength:
   Exclude:
     - "test/**/*"
 
+Metrics/ClassLength:
+  Exclude:
+    - "test/**/*"
+
 Metrics/AbcSize:
   Max: 40
   Exclude:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,7 @@ Three parallel jobs run on every push/PR to `main` (defined in `.github/workflow
 | Variable | Purpose |
 |----------|---------|
 | `ISBNDB_API_KEY` | ISBNdb API access (set to `test_dummy_key` in test) |
+| `ANTHROPIC_API_KEY` | Claude API access for `BookClassifier` / `books:classify` |
 | `S3_BUCKET` | Production image storage bucket |
 | `AWS_REGION` | AWS region for S3 |
 | `ACCESS_KEY` | AWS access key |

--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -23,6 +23,8 @@ module Api
               isbn: book.isbn,
               shelf_id: book.shelf_id,
               shelf_name: book.shelf.name,
+              classification: book.classification,
+              genres: book.genre_list,
               image_url: book_image_url(book),
               comments: book.comments.to_s
             }

--- a/app/controllers/api/v1/shelves_controller.rb
+++ b/app/controllers/api/v1/shelves_controller.rb
@@ -32,6 +32,8 @@ module Api
                   title: b.title,
                   author: b.author,
                   isbn: b.isbn,
+                  classification: b.classification,
+                  genres: b.genre_list,
                   image_url: book_image_url(b)
                 }
               end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,16 +2,29 @@
 #
 # Table name: books
 #
-#  id         :integer          not null, primary key
-#  author     :string
-#  isbn       :string
-#  title      :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  shelf_id   :integer
-#  user_id    :integer
+#  id             :integer          not null, primary key
+#  author         :string
+#  classification :string
+#  genres         :string
+#  isbn           :string
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  shelf_id       :integer
+#  user_id        :integer
 #
 class Book < ApplicationRecord
+  CLASSIFICATIONS = %w[fiction nonfiction].freeze
+
+  GENRES = [
+    "Science Fiction", "Fantasy", "Mystery & Thriller", "Literary Fiction",
+    "Historical Fiction", "Horror", "Romance", "Short Stories",
+    "Business", "Programming & Technical", "Science", "History",
+    "Biography & Memoir", "Self-Help", "Cooking", "Essays", "Philosophy",
+    "Psychology", "Politics & Society", "True Crime", "Poetry", "Reference",
+    "Parenting", "Health & Fitness", "Travel", "Art & Design", "Other"
+  ].freeze
+
   belongs_to :shelf
   belongs_to :user
   has_many :isbn_search_results, dependent: :destroy
@@ -19,7 +32,13 @@ class Book < ApplicationRecord
   has_one_attached :image
   has_rich_text :comments
 
+  validates :classification, inclusion: { in: CLASSIFICATIONS }, allow_nil: true
+
   def self.ransackable_attributes(_auth_object = nil)
-    %w[title author isbn]
+    %w[title author isbn classification genres]
+  end
+
+  def genre_list
+    genres.to_s.split(",").map(&:strip).reject(&:empty?)
   end
 end

--- a/app/models/book_classifier.rb
+++ b/app/models/book_classifier.rb
@@ -1,0 +1,84 @@
+# Classifies a book as fiction/nonfiction and assigns genres from the
+# controlled vocabulary in Book::GENRES, using the Claude API.
+#
+# Uses Net::HTTP rather than the official anthropic gem because the gem
+# requires Ruby >= 3.2 and this app runs 3.1.
+class BookClassifier
+  MODEL = "claude-haiku-4-5".freeze
+  API_URL = "https://api.anthropic.com/v1/messages".freeze
+
+  RESPONSE_SCHEMA = {
+    type: "object",
+    properties: {
+      classification: { type: "string", enum: Book::CLASSIFICATIONS },
+      genres: { type: "array", items: { type: "string", enum: Book::GENRES } }
+    },
+    required: %w[classification genres],
+    additionalProperties: false
+  }.freeze
+
+  attr_reader :book
+
+  def initialize(book:)
+    @book = book
+  end
+
+  def classify
+    result = request_classification
+    return false unless result
+
+    book.update(
+      classification: result["classification"],
+      genres: Array(result["genres"]).join(",")
+    )
+  end
+
+  private
+
+  def request_classification
+    response = post_request
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    body = JSON.parse(response.body)
+    JSON.parse(body.dig("content", 0, "text"))
+  rescue JSON::ParserError, TypeError, SocketError, Timeout::Error, SystemCallError
+    nil
+  end
+
+  def post_request
+    uri = URI(API_URL)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.read_timeout = 60
+
+    request = Net::HTTP::Post.new(uri, headers)
+    request.body = payload.to_json
+    http.request(request)
+  end
+
+  def headers
+    {
+      "x-api-key" => ENV.fetch("ANTHROPIC_API_KEY", nil),
+      "anthropic-version" => "2023-06-01",
+      "content-type" => "application/json"
+    }
+  end
+
+  def payload
+    {
+      model: MODEL,
+      max_tokens: 256,
+      output_config: { format: { type: "json_schema", schema: RESPONSE_SCHEMA } },
+      messages: [{ role: "user", content: prompt }]
+    }
+  end
+
+  def prompt
+    <<~PROMPT
+      Classify this book as fiction or nonfiction and pick 1-3 genres from the allowed list.
+
+      Title: #{book.title}
+      Author: #{book.author}
+    PROMPT
+  end
+end

--- a/app/models/isbn_search_result.rb
+++ b/app/models/isbn_search_result.rb
@@ -2,15 +2,19 @@
 #
 # Table name: isbn_search_results
 #
-#  id         :integer          not null, primary key
-#  authors    :string
-#  image_url  :string
-#  isbn10     :string
-#  isbn13     :string
-#  title      :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  book_id    :integer
+#  id             :integer          not null, primary key
+#  authors        :string
+#  date_published :string
+#  image_url      :string
+#  isbn10         :string
+#  isbn13         :string
+#  pages          :integer
+#  subjects       :string
+#  synopsis       :text
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  book_id        :integer
 #
 class IsbnSearchResult < ApplicationRecord
   belongs_to :book

--- a/app/models/isbn_searcher.rb
+++ b/app/models/isbn_searcher.rb
@@ -39,7 +39,11 @@ class IsbnSearcher
       isbn10: isbn_result[:isbn10],
       title: isbn_result[:title],
       authors: isbn_result[:authors].join(","),
-      image_url: isbn_result[:image]
+      image_url: isbn_result[:image],
+      subjects: isbn_result[:subjects]&.join(","),
+      synopsis: isbn_result[:synopsis],
+      pages: isbn_result[:pages],
+      date_published: isbn_result[:date_published]
     )
   end
 end

--- a/app/views/book_searches/index.html.erb
+++ b/app/views/book_searches/index.html.erb
@@ -4,6 +4,20 @@
   <%= search_form_for @q, url: book_searches_path do |f| %>
     <%= f.search_field :title_i_cont, placeholder: "Title search...", class: "form-control" %>
     <%= f.search_field :author_i_cont, placeholder: "Author search...", class: "form-control" %>
+    <div class="row g-2 my-1">
+      <div class="col">
+        <%= f.select :classification_eq,
+                     options_for_select(Book::CLASSIFICATIONS.map { |c| [c.capitalize, c] }, params.dig(:q, :classification_eq)),
+                     { include_blank: "Fiction & Nonfiction" },
+                     class: "form-select" %>
+      </div>
+      <div class="col">
+        <%= f.select :genres_cont,
+                     options_for_select(Book::GENRES, params.dig(:q, :genres_cont)),
+                     { include_blank: "Any genre" },
+                     class: "form-select" %>
+      </div>
+    </div>
     <div class="d-grid">
       <%= f.submit "Search", class: "btn btn-primary" %>
     </div>

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -11,6 +11,14 @@
           <h5 class="card-title"><%= book.title %></h5>
           <p class="card-text"><%= book.author %></p>
           <p class="card-text"><small class="text-body-secondary"><%= book.isbn %></small></p>
+          <p class="card-text">
+            <% if book.classification.present? %>
+              <span class="badge bg-secondary"><%= book.classification.capitalize %></span>
+            <% end %>
+            <% book.genre_list.each do |genre| %>
+              <span class="badge bg-info text-dark"><%= genre %></span>
+            <% end %>
+          </p>
         </div>
       </div>
     </div>

--- a/app/views/books/_list_item.html.erb
+++ b/app/views/books/_list_item.html.erb
@@ -16,6 +16,12 @@
       <% if !book.isbn.present? %>
         <span class="badge bg-danger">No ISBN</span>
       <% end %>
+      <% if book.classification.present? %>
+        <span class="badge bg-secondary"><%= book.classification.capitalize %></span>
+      <% end %>
+      <% book.genre_list.each do |genre| %>
+        <span class="badge bg-info text-dark"><%= genre %></span>
+      <% end %>
     </div>
   </div>          
 <% end %>

--- a/db/migrate/20260705222624_add_classification_and_genres_to_books.rb
+++ b/db/migrate/20260705222624_add_classification_and_genres_to_books.rb
@@ -1,0 +1,6 @@
+class AddClassificationAndGenresToBooks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :books, :classification, :string
+    add_column :books, :genres, :string
+  end
+end

--- a/db/migrate/20260705222625_add_metadata_to_isbn_search_results.rb
+++ b/db/migrate/20260705222625_add_metadata_to_isbn_search_results.rb
@@ -1,0 +1,8 @@
+class AddMetadataToIsbnSearchResults < ActiveRecord::Migration[7.0]
+  def change
+    add_column :isbn_search_results, :subjects, :string
+    add_column :isbn_search_results, :synopsis, :text
+    add_column :isbn_search_results, :pages, :integer
+    add_column :isbn_search_results, :date_published, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_02_131429) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_05_222625) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -57,6 +57,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_02_131429) do
     t.datetime "updated_at", null: false
     t.integer "shelf_id"
     t.integer "user_id"
+    t.string "classification"
+    t.string "genres"
   end
 
   create_table "isbn_search_results", force: :cascade do |t|
@@ -68,6 +70,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_02_131429) do
     t.string "isbn10"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "subjects"
+    t.text "synopsis"
+    t.integer "pages"
+    t.string "date_published"
   end
 
   create_table "shelves", force: :cascade do |t|

--- a/lib/tasks/books.rake
+++ b/lib/tasks/books.rake
@@ -1,0 +1,13 @@
+namespace :books do
+  desc "Classify unclassified books (fiction/nonfiction + genres) via the Claude API"
+  task classify: :environment do
+    scope = Book.where(classification: nil)
+    total = scope.count
+    puts "Classifying #{total} books..."
+
+    scope.find_each.with_index(1) do |book, index|
+      success = BookClassifier.new(book: book).classify
+      puts "[#{index}/#{total}] #{success ? 'ok' : 'FAILED'} - #{book.title}"
+    end
+  end
+end

--- a/test/controllers/api/v1/books_controller_test.rb
+++ b/test/controllers/api/v1/books_controller_test.rb
@@ -10,6 +10,8 @@ module Api
           title: "Test Book",
           author: "Test Author",
           isbn: "1234567890",
+          classification: "fiction",
+          genres: "Science Fiction,Fantasy",
           user: @user,
           shelf: @shelf
         )
@@ -46,6 +48,15 @@ module Api
         assert_not_includes titles, "Other Book"
       end
 
+      test "index includes classification and genres" do
+        get api_v1_books_url, params: { api_key: @user.api_key, user_id: @user.id }
+
+        book_json = response.parsed_body["books"].find { |b| b["title"] == "Test Book" }
+
+        assert_equal "fiction", book_json["classification"]
+        assert_equal "Science Fiction,Fantasy", book_json["genres"]
+      end
+
       test "index returns 401 without credentials" do
         get api_v1_books_url
 
@@ -63,6 +74,15 @@ module Api
         assert_equal @book.id, json_response["book"]["id"]
         assert_equal "Test Book", json_response["book"]["title"]
         assert_equal "Test Author", json_response["book"]["author"]
+      end
+
+      test "show includes classification and genre list" do
+        get api_v1_book_url(@book), params: { api_key: @user.api_key, user_id: @user.id }
+
+        book_json = response.parsed_body["book"]
+
+        assert_equal "fiction", book_json["classification"]
+        assert_equal ["Science Fiction", "Fantasy"], book_json["genres"]
       end
 
       test "should return 404 for non-existent book" do

--- a/test/controllers/api/v1/shelves_controller_test.rb
+++ b/test/controllers/api/v1/shelves_controller_test.rb
@@ -6,7 +6,8 @@ module Api
       setup do
         @user = User.create!(email: "shelves_api@example.com", password: "password123")
         @shelf = Shelf.create!(name: "My Shelf", user: @user)
-        @book = Book.create!(title: "Shelf Book", author: "Author", isbn: "111", user: @user, shelf: @shelf)
+        @book = Book.create!(title: "Shelf Book", author: "Author", isbn: "111",
+                             classification: "nonfiction", genres: "History", user: @user, shelf: @shelf)
 
         @other_user = User.create!(email: "other_shelves@example.com", password: "password123")
         @other_shelf = Shelf.create!(name: "Other Shelf", user: @other_user)
@@ -51,6 +52,15 @@ module Api
         assert_equal "My Shelf", json["shelf"]["name"]
         assert_equal 1, json["shelf"]["books"].length
         assert_equal "Shelf Book", json["shelf"]["books"].first["title"]
+      end
+
+      test "show includes classification and genre list on books" do
+        get api_v1_shelf_url(@shelf), params: { api_key: @user.api_key, user_id: @user.id }
+
+        book_json = response.parsed_body["shelf"]["books"].first
+
+        assert_equal "nonfiction", book_json["classification"]
+        assert_equal ["History"], book_json["genres"]
       end
 
       test "show returns 404 for non-existent shelf" do

--- a/test/controllers/book_searches_controller_test.rb
+++ b/test/controllers/book_searches_controller_test.rb
@@ -18,6 +18,48 @@ class BookSearchesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "filters books by classification" do
+    @user.books.create!(title: "Project Hail Mary", author: "Andy Weir",
+                        classification: "fiction", genres: "Science Fiction", shelf: shelves(:one))
+    @user.books.create!(title: "The Mom Test", author: "Rob Fitzpatrick",
+                        classification: "nonfiction", genres: "Business", shelf: shelves(:one))
+
+    get book_searches_url, params: { q: { classification_eq: "fiction" } }
+
+    assert_response :success
+    assert_match "Project Hail Mary", response.body
+    assert_no_match "The Mom Test", response.body
+  end
+
+  test "filters books by genre" do
+    @user.books.create!(title: "Project Hail Mary", author: "Andy Weir",
+                        classification: "fiction", genres: "Science Fiction", shelf: shelves(:one))
+    @user.books.create!(title: "Dune", author: "Frank Herbert",
+                        classification: "fiction", genres: "Science Fiction,Fantasy", shelf: shelves(:one))
+    @user.books.create!(title: "The Mom Test", author: "Rob Fitzpatrick",
+                        classification: "nonfiction", genres: "Business", shelf: shelves(:one))
+
+    get book_searches_url, params: { q: { genres_cont: "Science Fiction" } }
+
+    assert_response :success
+    assert_match "Project Hail Mary", response.body
+    assert_match "Dune", response.body
+    assert_no_match "The Mom Test", response.body
+  end
+
+  test "combines genre and classification filters with text search" do
+    @user.books.create!(title: "Project Hail Mary", author: "Andy Weir",
+                        classification: "fiction", genres: "Science Fiction", shelf: shelves(:one))
+    @user.books.create!(title: "Dune", author: "Frank Herbert",
+                        classification: "fiction", genres: "Science Fiction", shelf: shelves(:one))
+
+    get book_searches_url, params: { q: { genres_cont: "Science Fiction", title_i_cont: "dune" } }
+
+    assert_response :success
+    assert_match "Dune", response.body
+    assert_no_match "Project Hail Mary", response.body
+  end
+
   test "requires authentication" do
     sign_out @user
     get book_searches_url

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -2,14 +2,16 @@
 #
 # Table name: books
 #
-#  id         :integer          not null, primary key
-#  author     :string
-#  isbn       :string
-#  title      :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  shelf_id   :integer
-#  user_id    :integer
+#  id             :integer          not null, primary key
+#  author         :string
+#  classification :string
+#  genres         :string
+#  isbn           :string
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  shelf_id       :integer
+#  user_id        :integer
 #
 
 one:

--- a/test/fixtures/isbn_search_results.yml
+++ b/test/fixtures/isbn_search_results.yml
@@ -2,15 +2,19 @@
 #
 # Table name: isbn_search_results
 #
-#  id         :integer          not null, primary key
-#  authors    :string
-#  image_url  :string
-#  isbn10     :string
-#  isbn13     :string
-#  title      :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  book_id    :integer
+#  id             :integer          not null, primary key
+#  authors        :string
+#  date_published :string
+#  image_url      :string
+#  isbn10         :string
+#  isbn13         :string
+#  pages          :integer
+#  subjects       :string
+#  synopsis       :text
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  book_id        :integer
 #
 
 one:

--- a/test/models/book_classifier_test.rb
+++ b/test/models/book_classifier_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class BookClassifierTest < ActiveSupport::TestCase
+  setup do
+    @book = books(:one)
+    @classifier = BookClassifier.new(book: @book)
+  end
+
+  test "classify updates the book from the api response and returns true" do
+    response = http_response("200", {
+      content: [{ type: "text", text: { classification: "fiction", genres: ["Science Fiction", "Fantasy"] }.to_json }]
+    }.to_json)
+
+    result = @classifier.stub(:post_request, response) do
+      @classifier.classify
+    end
+
+    assert result
+    @book.reload
+
+    assert_equal "fiction", @book.classification
+    assert_equal "Science Fiction,Fantasy", @book.genres
+  end
+
+  test "classify returns false on an unsuccessful response" do
+    response = http_response("429", { error: { type: "rate_limit_error" } }.to_json, Net::HTTPTooManyRequests)
+
+    result = @classifier.stub(:post_request, response) do
+      @classifier.classify
+    end
+
+    assert_not result
+    assert_nil @book.reload.classification
+  end
+
+  test "classify returns false when the response is not parseable" do
+    response = http_response("200", "not json")
+
+    result = @classifier.stub(:post_request, response) do
+      @classifier.classify
+    end
+
+    assert_not result
+    assert_nil @book.reload.classification
+  end
+
+  test "classify does not persist a classification outside the vocabulary" do
+    response = http_response("200", {
+      content: [{ type: "text", text: { classification: "cookbook", genres: ["Cooking"] }.to_json }]
+    }.to_json)
+
+    result = @classifier.stub(:post_request, response) do
+      @classifier.classify
+    end
+
+    assert_not result
+    assert_nil @book.reload.classification
+  end
+
+  private
+
+  def http_response(code, body, klass = Net::HTTPOK)
+    response = klass.new("1.1", code, nil)
+    response.define_singleton_method(:body) { body }
+    response
+  end
+end

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: books
+#
+#  id             :integer          not null, primary key
+#  author         :string
+#  classification :string
+#  genres         :string
+#  isbn           :string
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  shelf_id       :integer
+#  user_id        :integer
+#
 require "test_helper"
 
 class BookTest < ActiveSupport::TestCase
@@ -33,7 +48,48 @@ class BookTest < ActiveSupport::TestCase
     end
   end
 
-  test "ransackable_attributes returns title author and isbn" do
-    assert_equal %w[title author isbn], Book.ransackable_attributes
+  test "ransackable_attributes returns title author isbn classification and genres" do
+    assert_equal %w[title author isbn classification genres], Book.ransackable_attributes
+  end
+
+  test "classification accepts fiction, nonfiction, and nil" do
+    book = books(:one)
+
+    book.classification = "fiction"
+
+    assert_predicate book, :valid?
+
+    book.classification = "nonfiction"
+
+    assert_predicate book, :valid?
+
+    book.classification = nil
+
+    assert_predicate book, :valid?
+  end
+
+  test "classification rejects other values" do
+    book = books(:one)
+    book.classification = "poetry"
+
+    assert_not_predicate book, :valid?
+  end
+
+  test "genre_list splits the genres string" do
+    book = books(:one)
+    book.genres = "Science Fiction, Fantasy"
+
+    assert_equal ["Science Fiction", "Fantasy"], book.genre_list
+  end
+
+  test "genre_list is empty when genres is blank" do
+    book = books(:one)
+    book.genres = nil
+
+    assert_empty book.genre_list
+  end
+
+  test "GENRES is a controlled vocabulary including Science Fiction" do
+    assert_includes Book::GENRES, "Science Fiction"
   end
 end

--- a/test/models/isbn_search_result_test.rb
+++ b/test/models/isbn_search_result_test.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: isbn_search_results
+#
+#  id             :integer          not null, primary key
+#  authors        :string
+#  date_published :string
+#  image_url      :string
+#  isbn10         :string
+#  isbn13         :string
+#  pages          :integer
+#  subjects       :string
+#  synopsis       :text
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  book_id        :integer
+#
 require "test_helper"
 
 class IsbnSearchResultTest < ActiveSupport::TestCase

--- a/test/models/isbn_searcher_test.rb
+++ b/test/models/isbn_searcher_test.rb
@@ -59,6 +59,55 @@ class IsbnSearcherTest < ActiveSupport::TestCase
     assert_equal "Author A", result.authors
   end
 
+  test "search persists subjects synopsis pages and date_published" do
+    mock_client = Minitest::Mock.new
+    mock_book_client = Minitest::Mock.new
+    mock_book_client.expect(:batch, {
+                              books: [
+                                {
+                                  isbn13: "9781111111111", isbn10: "1111111111", title: "Found Book",
+                                  authors: ["Author A"], image: "http://example.com/img.jpg",
+                                  subjects: ["Science Fiction", "Space Opera"],
+                                  synopsis: "A grand space adventure.",
+                                  pages: 432,
+                                  date_published: "2019"
+                                }
+                              ]
+                            }, [String])
+    mock_client.expect(:book, mock_book_client)
+
+    @searcher.stub(:client, mock_client) do
+      @searcher.search
+    end
+
+    result = @book.isbn_search_results.reload.last
+
+    assert_equal "Science Fiction,Space Opera", result.subjects
+    assert_equal "A grand space adventure.", result.synopsis
+    assert_equal 432, result.pages
+    assert_equal "2019", result.date_published
+  end
+
+  test "search tolerates results without extended metadata" do
+    mock_client = Minitest::Mock.new
+    mock_book_client = Minitest::Mock.new
+    mock_book_client.expect(:batch, {
+                              books: [
+                                { isbn13: "9781111111111", isbn10: "1111111111", title: "Found Book", authors: ["Author A"], image: "http://example.com/img.jpg" }
+                              ]
+                            }, [String])
+    mock_client.expect(:book, mock_book_client)
+
+    @searcher.stub(:client, mock_client) do
+      @searcher.search
+    end
+
+    result = @book.isbn_search_results.reload.last
+
+    assert_nil result.subjects
+    assert_nil result.pages
+  end
+
   test "search returns false on api error" do
     mock_client = Minitest::Mock.new
     mock_book_client = Minitest::Mock.new

--- a/test/models/shelf_test.rb
+++ b/test/models/shelf_test.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: shelves
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :integer
+#
 require "test_helper"
 
 class ShelfTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  api_key                :string
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  shelf_id               :integer
+#
+# Indexes
+#
+#  index_users_on_api_key               (api_key) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase


### PR DESCRIPTION
## Summary

Implements BOOK-11: makes the library answer questions like "what unread scifi do we own?" by adding fiction/nonfiction classification and genre metadata to books, capturing the ISBNdb metadata we were previously discarding, and providing an LLM backfill path for the existing ~1,000-book library.

## Requirements

- Every book can carry a `classification` (fiction/nonfiction) and 1–3 `genres` from a controlled vocabulary
- Existing library is backfillable without ISBNs (22% of books lack one)
- Genre + classification are filterable in the web search UI and visible in the JSON API (iOS app)
- ISBN searches stop throwing away subjects/synopsis/pages/publish date

## What changed

**Schema** (2 migrations)
- `books`: + `classification` (string, validated fiction/nonfiction), + `genres` (comma-separated string from `Book::GENRES`)
- `isbn_search_results`: + `subjects`, `synopsis`, `pages`, `date_published`

**Services**
- `BookClassifier` (new): sends title+author to Claude Haiku (`claude-haiku-4-5`) with a JSON-schema-constrained response (`output_config.format`), so the reply is guaranteed to be `{classification, genres[]}` drawn from the allowed enums. Uses Net::HTTP because the official `anthropic` gem requires Ruby ≥ 3.2 and this app runs 3.1.2. Failures (non-200, unparseable, out-of-vocab) return `false` and leave the book untouched.
- `IsbnSearcher`: persists the full ISBNdb metadata instead of dropping it.

**Backfill**
- `bin/rails books:classify` — iterates `Book.where(classification: nil)`, idempotent, logs per-book progress. ~1,062 books ≈ a few dollars on Haiku.

**Web**
- `/book_searches`: classification + genre dropdowns (Ransack `classification_eq` / `genres_cont`)
- Book list items and cards show classification/genre badges

**API**
- `GET /api/v1/books` (index): rows now include `classification` + `genres`
- `GET /api/v1/books/:id` and `GET /api/v1/shelves/:id`: books include `classification` + `genres` (genres as an array)

## Testing

TDD throughout (red → green per milestone). 104 runs, 199 assertions, 0 failures. Rubocop clean (added `Metrics/ClassLength` test exclusion, matching the existing convention for the other Metrics cops). Brakeman clean with CI flags.

LLM calls are mocked at the HTTP boundary (`post_request`), matching the repo's existing ISBNdb mocking pattern — no network in tests.

## Deployment notes

- Run `bin/rails db:migrate`
- Set `ANTHROPIC_API_KEY` in production env (documented in CLAUDE.md)
- Run `bin/rails books:classify` once to backfill; re-run any time for new unclassified books

## Out of scope (see BOOK-11)

- First-class read status/rating (currently encoded in shelf names) — natural follow-on
- Re-pulling current prod DB for refreshed scoping counts (still blocked on SSH access to the Hatchbox box)

🤖 Generated with [Claude Code](https://claude.com/claude-code)