### PR TITLE
Add DEPLOY.md, ROADMAP.md, and real README (BOOK-11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ IsbnSearchResult
 | `config/routes.rb` | All route definitions |
 | `db/schema.rb` | Current database schema |
 | `test/` | Minitest test suite |
-| `doc/` | API docs, PRD, SDD |
+| `doc/` | API docs, PRD, SDD, [ROADMAP.md](doc/ROADMAP.md) (improvement priorities), [DEPLOY.md](doc/DEPLOY.md) (production ops) |
 
 ## Engineering Methodology
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
-# README
+# BookTracker (Reader)
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+A Rails 7 web + API application for cataloging a personal book library. Books are organized into shelves, enriched with metadata from ISBNdb and Claude (fiction/nonfiction classification + genres), and served to both a web UI and a JSON API consumed by a companion iOS app.
 
-Things you may want to cover:
+## Quick start
 
-* Ruby version
+```bash
+bundle install
+bin/rails db:setup
+bin/rails server          # http://localhost:3000
+bin/rails test
+```
 
-* System dependencies
+## Documentation
 
-* Configuration
+- **[CLAUDE.md](CLAUDE.md)** — architecture, data model, testing conventions, and engineering methodology (start here)
+- **[doc/ROADMAP.md](doc/ROADMAP.md)** — improvement priorities and the analysis behind them
+- **[doc/DEPLOY.md](doc/DEPLOY.md)** — production setup (Hatchbox) and operations
+- **[doc/api.md](doc/api.md)** — JSON API reference
 
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+Work is tracked in the WCP **BOOK** namespace; commits reference callsigns (e.g. `BOOK-11`).

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -1,0 +1,53 @@
+# Deployment
+
+Production is a **Hatchbox-managed DigitalOcean droplet**. Everything below was verified against the live server (July 2026).
+
+## Topology
+
+| Thing | Value |
+|---|---|
+| Server | `cold-wind-4102` — `147.182.181.10` (shared with davepaola-com, pet-med-reminder, show-notes) |
+| SSH | `ssh deploy@147.182.181.10` |
+| App root | `/home/deploy/book-tracker/` (Capistrano-style: `current` → `releases/<timestamp>`, plus `repo` and `shared`) |
+| Ruby | 3.1.2 via asdf (`~/.tool-versions` in the release dir) |
+| App server | Puma, run as a **user systemd service**: `book-tracker-server.service`, bound to `127.0.0.1:$PORT` |
+| Database | SQLite: `/home/deploy/book-tracker/shared/production.sqlite3` |
+| Logs | `/home/deploy/book-tracker/shared/log/` |
+| Env vars | Managed in the Hatchbox dashboard; injected via `EnvironmentFile=~/book-tracker/.asdf-vars` |
+
+## Deploying
+
+**Merging/pushing to `main` auto-deploys** via Hatchbox's GitHub integration. There is no manual deploy step. Migrations run as part of the deploy.
+
+The `heroku` git remote and the Postgres dumps in `database-backups/` are relics of the pre-Nov-2023 Heroku deployment (retired when PR #20 moved the app to SQLite). Ignore them.
+
+## Common operations
+
+All of these need a login shell (`bash -lc`) so asdf + env vars load.
+
+```bash
+# One-off rake task / console
+ssh deploy@147.182.181.10
+cd ~/book-tracker/current
+RAILS_ENV=production bundle exec rails console
+RAILS_ENV=production bundle exec rails books:classify
+
+# Restart the app
+systemctl --user restart book-tracker-server
+
+# Tail app logs
+tail -f ~/book-tracker/shared/log/production.log
+```
+
+## Pulling a copy of the production DB
+
+```bash
+ssh deploy@147.182.181.10 'sqlite3 ~/book-tracker/shared/production.sqlite3 ".backup /tmp/book-tracker-prod.sqlite3"'
+scp deploy@147.182.181.10:/tmp/book-tracker-prod.sqlite3 ./
+```
+
+## Gotchas
+
+- **Long rake tasks buffer their output.** stdout redirected to a file is block-buffered (~8KB chunks), so a log can look stalled while the task is working. `lib/tasks/books.rake` sets `$stdout.sync = true`; do the same in new tasks, or check the DB for real progress.
+- The `deploy` user's non-login shell has no Ruby on PATH — always `bash -lc` for scripted SSH commands.
+- Rails warns about SQLite in production on every boot; known and accepted (single-user app).

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -1,0 +1,46 @@
+# Roadmap: Highest-Leverage Improvements
+
+Outcome of a full review (code, GitHub repo, WCP BOOK namespace) in July 2026. This doc records the analysis and priorities so future work doesn't re-derive them. Work items live in the WCP **BOOK** namespace.
+
+## Where the app stood at review time
+
+- `books` carried only `title`, `author`, `isbn`, `shelf_id`, `user_id` — no genre, classification, read status, or rating.
+- **Status and sentiment were encoded in shelf names** ("👍 Books: Liked", "📚 To Read", "📖 In Progress", "👎 Abandoned / Disliked"). 10 of 12 shelves encoded status/sentiment; only 2 (🥙 Cookbooks, 💻 Programming Reference) were genre-ish. Nothing in the DB could answer "what scifi do we own?"
+- `IsbnSearcher` discarded ISBNdb's `subjects`, `synopsis`, `pages`, and `date_published` — thousands of prior lookups stored no subject data.
+- No DB indexes on `books.user_id`/`shelf_id`, no foreign keys, API auth via `api_key` + `user_id` as request params.
+- Scoping data: 1,062 books in the Nov 2023 dump (`database-backups/dump.sql`), 1,272 in production at review time. ~78% had ISBNs. Single user.
+
+## Priority 1 — Genre + fiction/nonfiction metadata enrichment ✅ SHIPPED
+
+**BOOK-11**, PR #28 (merged July 2026). Motivating use case: new Kindle, wanted to find good unread scifi already in the catalog.
+
+Key decisions, and why:
+
+- **LLM-first backfill** (Claude Haiku, title+author → `{classification, genres[]}`) rather than metadata-lookup-first: 22% of books lack ISBNs, ISBNdb subject quality is inconsistent, and the existing 3,934 `isbn_search_results` rows contained no subject data anyway. ~1,272 books cost a few dollars.
+- **Controlled genre vocabulary** (`Book::GENRES`, 27 values) enforced via JSON-schema-constrained API output — free-form genres would make filtering useless.
+- **Structured facts as columns** (`classification`, `genres` on books), **raw source payloads retained** on `isbn_search_results` (subjects/synopsis/pages/date_published now persisted) so classification can be re-derived later.
+- Prior art considered: ISBNdb `subjects` (inconsistent), BISAC codes via Google Books/Open Library (`FIC*` prefix = fiction; good fallback source), GoodReads CSV (exports no genres). LLM classification won on accuracy and coverage.
+
+Backfill: `bin/rails books:classify` (idempotent — only touches `classification: nil`).
+
+## Priority 2 — First-class `status` and `rating` on Book (proposed)
+
+Free the shelves: add `status` (to_read / reading / read / abandoned) and a rating ("Loved, Meh, Disliked" — GitHub issue #6) as columns, so shelves can become collections/genres instead of encoding state in emoji names. Combined with Priority 1, "good unread scifi we own" becomes one query. The GoodReads importer already has this signal (`Exclusive Shelf`, `My Rating`) and currently lossy-compresses it into shelf names.
+
+## Priority 3 — Foundation hardening (proposed)
+
+- Indexes on `books.user_id`, `books.shelf_id`, `shelves.user_id` — every page scans without them.
+- NOT NULL constraints + foreign keys (associations are Rails-only today).
+- API auth: move from `api_key`+`user_id` request params (credentials end up in logs; `user_id` is redundant) to an `Authorization` header, look up by key alone. Requires a coordinated iOS app update.
+- Dependabot: ~100 open vulnerability alerts on the repo (3 critical, 22 high as of July 2026).
+
+## Also unblocked by Priority 1
+
+- GitHub issue #10 (book synopses) — synopses now captured at ISBN-search time.
+- GitHub issue #19 (GPT suggestions) — a recommender needs the metadata that now exists.
+
+## Related docs
+
+- [DEPLOY.md](DEPLOY.md) — production setup and operations
+- [CLAUDE.md](../CLAUDE.md) — architecture and engineering methodology
+- BOOK-11 in WCP — full brief, activity log, and scoping detail

--- a/lib/tasks/books.rake
+++ b/lib/tasks/books.rake
@@ -1,6 +1,7 @@
 namespace :books do
   desc "Classify unclassified books (fiction/nonfiction + genres) via the Claude API"
   task classify: :environment do
+    $stdout.sync = true
     scope = Book.where(classification: nil)
     total = scope.count
     puts "Classifying #{total} books..."


### PR DESCRIPTION
## Summary

Closes out the remaining BOOK-11 pre-flight item (deployment was undocumented) and captures the July 2026 review discussion as a durable doc.

**doc/DEPLOY.md** — the Hatchbox production setup, all verified against the live server:
- DigitalOcean droplet `cold-wind-4102` (147.182.181.10), Capistrano-style layout under `/home/deploy/book-tracker/`
- Auto-deploy on merge to `main` via Hatchbox GitHub integration (migrations included)
- One-off task / console / restart / log workflows, and how to pull a copy of the production SQLite DB
- Gotchas discovered while running the genre backfill (stdout block-buffering in nohup'd rake tasks, login-shell requirement for asdf)

**doc/ROADMAP.md** — the original review analysis: where the schema stood, the top-3 priorities (metadata enrichment ✅ shipped in #28; status/rating on Book; foundation hardening incl. the ~100 Dependabot alerts), and the prior-art reasoning behind LLM-first genre classification. Linked from README.md and CLAUDE.md.

**README.md** — replaced the untouched Rails boilerplate with a short real README pointing at the docs.

Also sets `$stdout.sync = true` in `books:classify` so its progress log streams line-by-line instead of arriving in 8KB chunks.

## Testing

Docs + a buffering flag on an already-tested task; full suite green locally (104 runs), rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)