### PR TITLE
Add library dashboard homepage (BOOK-12)

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,7 @@
 class HomeController < ApplicationController
-  def index; end
+  before_action :authenticate_user!
+
+  def index
+    @dashboard = LibraryDashboard.new(user: current_user)
+  end
 end

--- a/app/models/library_dashboard.rb
+++ b/app/models/library_dashboard.rb
@@ -1,0 +1,48 @@
+# Aggregates a user's library stats for the homepage dashboard.
+class LibraryDashboard
+  attr_reader :user
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def book_count
+    user.books.count
+  end
+
+  def shelf_count
+    user.shelves.count
+  end
+
+  def fiction_count
+    user.books.where(classification: "fiction").count
+  end
+
+  def nonfiction_count
+    user.books.where(classification: "nonfiction").count
+  end
+
+  def unclassified_count
+    user.books.where(classification: nil).count
+  end
+
+  def top_genres(limit: 8)
+    user.books.where.not(genres: [nil, ""])
+        .pluck(:genres)
+        .flat_map { |genres| genres.split(",").map(&:strip) }
+        .tally
+        .sort_by { |genre, count| [-count, genre] }
+        .first(limit)
+  end
+
+  def recently_updated(limit: 10)
+    user.books.order(updated_at: :desc).limit(limit)
+  end
+
+  def shelves_with_recent_books(limit: 10)
+    user.shelves
+        .sort_by { |shelf| -shelf.books.count }
+        .map { |shelf| [shelf, shelf.books.order(created_at: :desc).limit(limit).to_a] }
+        .reject { |_shelf, books| books.empty? }
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,84 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<h1>Your Library</h1>
+
+<div class="row g-3 mb-4 text-center">
+  <div class="col-6 col-md-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h2 class="mb-0"><%= @dashboard.book_count %></h2>
+        <small class="text-body-secondary">Books</small>
+      </div>
+    </div>
+  </div>
+  <div class="col-6 col-md-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h2 class="mb-0"><%= @dashboard.shelf_count %></h2>
+        <small class="text-body-secondary">Shelves</small>
+      </div>
+    </div>
+  </div>
+  <div class="col-6 col-md-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h2 class="mb-0"><%= @dashboard.fiction_count %></h2>
+        <small class="text-body-secondary">Fiction</small>
+      </div>
+    </div>
+  </div>
+  <div class="col-6 col-md-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h2 class="mb-0"><%= @dashboard.nonfiction_count %></h2>
+        <small class="text-body-secondary">Nonfiction</small>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">Top genres</div>
+  <div class="card-body">
+    <% @dashboard.top_genres.each do |genre, count| %>
+      <%= link_to book_searches_path(q: { genres_cont: genre }), class: "text-decoration-none" do %>
+        <span class="badge bg-info text-dark fs-6 mb-1"><%= genre %> <span class="badge bg-dark"><%= count %></span></span>
+      <% end %>
+    <% end %>
+    <% if @dashboard.unclassified_count.positive? %>
+      <span class="badge bg-warning text-dark fs-6 mb-1"><%= @dashboard.unclassified_count %> unclassified</span>
+    <% end %>
+  </div>
+</div>
+
+<div class="row g-3">
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header">Recently updated</div>
+      <div class="list-group list-group-flush">
+        <% @dashboard.recently_updated.each do |book| %>
+          <%= link_to book_path(book), class: "list-group-item list-group-item-action" do %>
+            <%= book.title %>
+            <% if book.classification.present? %>
+              <span class="badge bg-secondary"><%= book.classification.capitalize %></span>
+            <% end %>
+            <small class="text-body-secondary d-block"><%= time_ago_in_words(book.updated_at) %> ago</small>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-6">
+    <% @dashboard.shelves_with_recent_books.each do |shelf, books| %>
+      <div class="card mb-3">
+        <div class="card-header">
+          <%= link_to shelf.name, shelf_path(shelf), class: "text-decoration-none" %>
+        </div>
+        <div class="list-group list-group-flush">
+          <% books.each do |book| %>
+            <%= link_to book.title, book_path(book), class: "list-group-item list-group-item-action" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,5 +24,5 @@ Rails.application.routes.draw do
 
   resources :api_docs, only: [:index]
   
-  root "shelves#index"
+  root "home#index"
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -6,9 +6,38 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
-  test "should get index" do
+  test "root renders the dashboard" do
     get root_url
 
     assert_response :success
+    assert_match "Library", response.body
+  end
+
+  test "shows library stats" do
+    @user.books.create!(title: "Dune Dashboard Test", shelf: shelves(:one),
+                        classification: "fiction", genres: "Science Fiction")
+
+    get root_url
+
+    assert_match "Fiction", response.body
+    assert_match "Nonfiction", response.body
+    assert_match "Science Fiction", response.body
+  end
+
+  test "shows recent books per shelf and recently updated" do
+    @user.books.create!(title: "Dashboard Recent Book", shelf: shelves(:one))
+
+    get root_url
+
+    assert_match "Dashboard Recent Book", response.body
+    assert_match shelves(:one).name, response.body
+    assert_match "Recently updated", response.body
+  end
+
+  test "requires authentication" do
+    sign_out @user
+    get root_url
+
+    assert_redirected_to new_user_session_url
   end
 end

--- a/test/models/library_dashboard_test.rb
+++ b/test/models/library_dashboard_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class LibraryDashboardTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(email: "dashboard@example.com", password: "password123")
+    @scifi_shelf = Shelf.create!(name: "Scifi", user: @user)
+    @biz_shelf = Shelf.create!(name: "Business", user: @user)
+    @dashboard = LibraryDashboard.new(user: @user)
+  end
+
+  test "counts books and shelves for the user only" do
+    @user.books.create!(title: "Dune", shelf: @scifi_shelf, classification: "fiction", genres: "Science Fiction")
+
+    other_user = users(:one)
+
+    assert_equal 1, @dashboard.book_count
+    assert_equal 2, @dashboard.shelf_count
+    assert_not_equal other_user.books.count, 0
+  end
+
+  test "counts by classification" do
+    @user.books.create!(title: "Dune", shelf: @scifi_shelf, classification: "fiction", genres: "Science Fiction")
+    @user.books.create!(title: "Hyperion", shelf: @scifi_shelf, classification: "fiction", genres: "Science Fiction")
+    @user.books.create!(title: "The Mom Test", shelf: @biz_shelf, classification: "nonfiction", genres: "Business")
+    @user.books.create!(title: "Mystery Book", shelf: @biz_shelf)
+
+    assert_equal 2, @dashboard.fiction_count
+    assert_equal 1, @dashboard.nonfiction_count
+    assert_equal 1, @dashboard.unclassified_count
+  end
+
+  test "top_genres tallies comma-separated genres in descending order" do
+    @user.books.create!(title: "Dune", shelf: @scifi_shelf, classification: "fiction", genres: "Science Fiction,Fantasy")
+    @user.books.create!(title: "Hyperion", shelf: @scifi_shelf, classification: "fiction", genres: "Science Fiction")
+    @user.books.create!(title: "The Mom Test", shelf: @biz_shelf, classification: "nonfiction", genres: "Business")
+
+    assert_equal [["Science Fiction", 2], ["Business", 1], ["Fantasy", 1]].sort, @dashboard.top_genres.sort
+    assert_equal ["Science Fiction", 2], @dashboard.top_genres.first
+  end
+
+  test "top_genres respects the limit" do
+    @user.books.create!(title: "Dune", shelf: @scifi_shelf, classification: "fiction", genres: "Science Fiction,Fantasy,Horror")
+
+    assert_equal 2, @dashboard.top_genres(limit: 2).length
+  end
+
+  test "recently_updated returns newest first with a limit" do
+    oldest = @user.books.create!(title: "Oldest", shelf: @scifi_shelf)
+    newest = @user.books.create!(title: "Newest", shelf: @scifi_shelf)
+    oldest.update!(updated_at: 2.days.ago)
+    newest.update!(updated_at: 1.minute.ago)
+
+    assert_equal [newest, oldest], @dashboard.recently_updated
+    assert_equal [newest], @dashboard.recently_updated(limit: 1)
+  end
+
+  test "shelves_with_recent_books returns each shelf with its newest books" do
+    old_book = @user.books.create!(title: "Old Scifi", shelf: @scifi_shelf, created_at: 2.days.ago)
+    new_book = @user.books.create!(title: "New Scifi", shelf: @scifi_shelf, created_at: 1.minute.ago)
+    biz_book = @user.books.create!(title: "Biz", shelf: @biz_shelf)
+
+    result = @dashboard.shelves_with_recent_books
+
+    assert_equal 2, result.length
+
+    scifi_entry = result.find { |shelf, _books| shelf == @scifi_shelf }
+
+    assert_equal [new_book, old_book], scifi_entry.last
+
+    biz_entry = result.find { |shelf, _books| shelf == @biz_shelf }
+
+    assert_equal [biz_book], biz_entry.last
+  end
+
+  test "shelves_with_recent_books limits books per shelf and orders shelves by book count" do
+    3.times { |i| @user.books.create!(title: "Scifi #{i}", shelf: @scifi_shelf) }
+    @user.books.create!(title: "Biz", shelf: @biz_shelf)
+
+    result = @dashboard.shelves_with_recent_books(limit: 2)
+
+    assert_equal @scifi_shelf, result.first.first
+    assert_equal 2, result.first.last.length
+  end
+
+  test "handles an empty library" do
+    empty_user = User.create!(email: "empty@example.com", password: "password123")
+    dashboard = LibraryDashboard.new(user: empty_user)
+
+    assert_equal 0, dashboard.book_count
+    assert_empty dashboard.top_genres
+    assert_empty dashboard.recently_updated
+    assert_empty dashboard.shelves_with_recent_books
+  end
+end


### PR DESCRIPTION
## Summary

Implements BOOK-12: the root page is now a library dashboard, surfacing the stats produced by the BOOK-11 genre backfill.

- **Stat tiles**: total books, shelves, fiction count, nonfiction count
- **Top genres**: badge per genre with its count — each badge links straight into `/book_searches` pre-filtered to that genre (one click from "Science Fiction: 180" to the actual list)
- **Recently updated**: latest 10 books by `updated_at`, with classification badge and relative time
- **Per-shelf recent additions**: a card per shelf (ordered by shelf size, empty shelves hidden) listing its 10 newest books
- An "N unclassified" warning badge appears only when unclassified books exist

The shelves index is unchanged and still lives at `/shelves` (navbar already links it).

## Design

`LibraryDashboard` (app/models/, per repo convention) owns all aggregation; `HomeController#index` instantiates that single object (Sandi Metz controller rule). The vestigial `HomeController`/`home#index` stub from 2023 was repurposed rather than adding a new controller.

## Testing

TDD (red → green): 8 new model tests for `LibraryDashboard` (counts, genre tally, ordering, per-shelf limits, user scoping, empty library) + 4 controller tests (dashboard renders at root, stats/sections present, auth required). Full suite: 115 runs, 237 assertions, 0 failures. Rubocop clean.

Also verified against a copy of the production database: 1,243 books / 14 shelves computes in 57ms and renders 13 shelf sections + all stats correctly. (System tests can't run in this environment — the `webdrivers` gem fails on an SSL cert error at load time, pre-existing; the navbar system tests only assert layout content, which is unchanged.)

Related: BOOK-11 / #28 (the metadata this surfaces), doc/ROADMAP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)