### PR TITLE
Rework dashboard IA: reading hero, recently added, tiered shelves (BOOK-13)

### DIFF
--- a/app/models/library_dashboard.rb
+++ b/app/models/library_dashboard.rb
@@ -1,5 +1,14 @@
 # Aggregates a user's library stats for the homepage dashboard.
 class LibraryDashboard
+  # Shelves with no additions inside this window collapse to count-only rows.
+  ACTIVE_WINDOW = 6.months
+
+  # The "currently reading" shelf is found by name until read status is
+  # first-class data (see doc/ROADMAP.md, Priority 2).
+  READING_SHELF_PATTERN = /in progress/i
+
+  ShelfSummary = Struct.new(:shelf, :book_count, :recent_books, :latest_added_at, keyword_init: true)
+
   attr_reader :user
 
   def initialize(user:)
@@ -35,14 +44,43 @@ class LibraryDashboard
         .first(limit)
   end
 
-  def recently_updated(limit: 10)
-    user.books.order(updated_at: :desc).limit(limit)
+  def recently_added(limit: 10)
+    user.books.order(created_at: :desc).limit(limit)
   end
 
-  def shelves_with_recent_books(limit: 10)
+  def currently_reading
+    shelf = reading_shelf
+    return nil unless shelf
+
+    [shelf, shelf.books.order(created_at: :desc).to_a]
+  end
+
+  def shelf_summaries(recent_limit: 3)
     user.shelves
-        .sort_by { |shelf| -shelf.books.count }
-        .map { |shelf| [shelf, shelf.books.order(created_at: :desc).limit(limit).to_a] }
-        .reject { |_shelf, books| books.empty? }
+        .reject { |shelf| shelf == reading_shelf }
+        .filter_map { |shelf| summarize(shelf, recent_limit) }
+        .sort_by { |summary| -summary.latest_added_at.to_i }
+  end
+
+  private
+
+  def reading_shelf
+    return @reading_shelf if defined?(@reading_shelf)
+
+    @reading_shelf = user.shelves.detect { |shelf| shelf.name =~ READING_SHELF_PATTERN }
+  end
+
+  def summarize(shelf, recent_limit)
+    newest = shelf.books.order(created_at: :desc).first
+    return nil unless newest
+
+    active = newest.created_at >= ACTIVE_WINDOW.ago
+
+    ShelfSummary.new(
+      shelf: shelf,
+      book_count: shelf.books.count,
+      recent_books: active ? shelf.books.order(created_at: :desc).limit(recent_limit).to_a : [],
+      latest_added_at: newest.created_at
+    )
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,36 +2,44 @@
 
 <div class="row g-3 mb-4 text-center">
   <div class="col-6 col-md-3">
-    <div class="card h-100">
-      <div class="card-body">
-        <h2 class="mb-0"><%= @dashboard.book_count %></h2>
-        <small class="text-body-secondary">Books</small>
+    <%= link_to books_path, class: "text-decoration-none text-reset" do %>
+      <div class="card h-100">
+        <div class="card-body">
+          <h2 class="mb-0"><%= @dashboard.book_count %></h2>
+          <small class="text-body-secondary">Books</small>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
   <div class="col-6 col-md-3">
-    <div class="card h-100">
-      <div class="card-body">
-        <h2 class="mb-0"><%= @dashboard.shelf_count %></h2>
-        <small class="text-body-secondary">Shelves</small>
+    <%= link_to shelves_path, class: "text-decoration-none text-reset" do %>
+      <div class="card h-100">
+        <div class="card-body">
+          <h2 class="mb-0"><%= @dashboard.shelf_count %></h2>
+          <small class="text-body-secondary">Shelves</small>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
   <div class="col-6 col-md-3">
-    <div class="card h-100">
-      <div class="card-body">
-        <h2 class="mb-0"><%= @dashboard.fiction_count %></h2>
-        <small class="text-body-secondary">Fiction</small>
+    <%= link_to book_searches_path(q: { classification_eq: "fiction" }), class: "text-decoration-none text-reset" do %>
+      <div class="card h-100">
+        <div class="card-body">
+          <h2 class="mb-0"><%= @dashboard.fiction_count %></h2>
+          <small class="text-body-secondary">Fiction</small>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
   <div class="col-6 col-md-3">
-    <div class="card h-100">
-      <div class="card-body">
-        <h2 class="mb-0"><%= @dashboard.nonfiction_count %></h2>
-        <small class="text-body-secondary">Nonfiction</small>
+    <%= link_to book_searches_path(q: { classification_eq: "nonfiction" }), class: "text-decoration-none text-reset" do %>
+      <div class="card h-100">
+        <div class="card-body">
+          <h2 class="mb-0"><%= @dashboard.nonfiction_count %></h2>
+          <small class="text-body-secondary">Nonfiction</small>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>
 
@@ -49,18 +57,45 @@
   </div>
 </div>
 
+<% if @dashboard.currently_reading %>
+  <% reading_shelf, reading_books = @dashboard.currently_reading %>
+  <div class="card mb-4">
+    <div class="card-header"><%= link_to reading_shelf.name, shelf_path(reading_shelf), class: "text-decoration-none" %></div>
+    <div class="card-body">
+      <div class="row g-3">
+        <% reading_books.each do |book| %>
+          <div class="col-4 col-md-2">
+            <%= link_to book_path(book), class: "text-decoration-none text-reset", title: book.title do %>
+              <% if book.image.attached? %>
+                <%= image_tag book.image, class: "img-fluid rounded shadow-sm" %>
+              <% elsif book.isbn_search_results.first&.image_url.present? %>
+                <%= image_tag book.isbn_search_results.first.image_url, class: "img-fluid rounded shadow-sm" %>
+              <% else %>
+                <div class="border rounded p-2 h-100 d-flex align-items-center text-center">
+                  <small><%= book.title %></small>
+                </div>
+              <% end %>
+              <small class="d-block text-truncate mt-1"><%= book.title %></small>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="row g-3">
   <div class="col-md-6">
     <div class="card mb-3">
-      <div class="card-header">Recently updated</div>
+      <div class="card-header">Recently added</div>
       <div class="list-group list-group-flush">
-        <% @dashboard.recently_updated.each do |book| %>
+        <% @dashboard.recently_added.each do |book| %>
           <%= link_to book_path(book), class: "list-group-item list-group-item-action" do %>
             <%= book.title %>
             <% if book.classification.present? %>
               <span class="badge bg-secondary"><%= book.classification.capitalize %></span>
             <% end %>
-            <small class="text-body-secondary d-block"><%= time_ago_in_words(book.updated_at) %> ago</small>
+            <small class="text-body-secondary d-block"><%= time_ago_in_words(book.created_at) %> ago</small>
           <% end %>
         <% end %>
       </div>
@@ -68,14 +103,35 @@
   </div>
 
   <div class="col-md-6">
-    <% @dashboard.shelves_with_recent_books.each do |shelf, books| %>
+    <% active, quiet = @dashboard.shelf_summaries.partition { |summary| summary.recent_books.any? } %>
+
+    <% active.each do |summary| %>
       <div class="card mb-3">
         <div class="card-header">
-          <%= link_to shelf.name, shelf_path(shelf), class: "text-decoration-none" %>
+          <%= link_to summary.shelf.name, shelf_path(summary.shelf), class: "text-decoration-none" %>
+          <span class="badge bg-secondary float-end"><%= summary.book_count %></span>
         </div>
         <div class="list-group list-group-flush">
-          <% books.each do |book| %>
+          <% summary.recent_books.each do |book| %>
             <%= link_to book.title, book_path(book), class: "list-group-item list-group-item-action" %>
+          <% end %>
+          <% if summary.book_count > summary.recent_books.length %>
+            <%= link_to "and #{summary.book_count - summary.recent_books.length} more…", shelf_path(summary.shelf),
+                        class: "list-group-item list-group-item-action text-body-secondary" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <% if quiet.any? %>
+      <div class="card mb-3">
+        <div class="card-header">Quieter shelves</div>
+        <div class="list-group list-group-flush">
+          <% quiet.each do |summary| %>
+            <%= link_to shelf_path(summary.shelf), class: "list-group-item list-group-item-action d-flex justify-content-between" do %>
+              <span><%= summary.shelf.name %></span>
+              <span class="badge bg-secondary"><%= summary.book_count %></span>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -24,14 +24,36 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_match "Science Fiction", response.body
   end
 
-  test "shows recent books per shelf and recently updated" do
+  test "shows recent books per shelf and recently added" do
     @user.books.create!(title: "Dashboard Recent Book", shelf: shelves(:one))
 
     get root_url
 
     assert_match "Dashboard Recent Book", response.body
     assert_match shelves(:one).name, response.body
-    assert_match "Recently updated", response.body
+    assert_match "Recently added", response.body
+    assert_no_match "Recently updated", response.body
+  end
+
+  test "shows the currently reading hero when an in-progress shelf exists" do
+    reading_shelf = Shelf.create!(name: "📖 In Progress", user: @user)
+    @user.books.create!(title: "Book Being Read Now", shelf: reading_shelf)
+
+    get root_url
+
+    assert_match "Book Being Read Now", response.body
+    assert_match "In Progress", response.body
+  end
+
+  test "collapses inactive shelves to a count row without listing books" do
+    dusty_shelf = Shelf.create!(name: "Dusty Archive", user: @user)
+    @user.books.create!(title: "Forgotten Tome", shelf: dusty_shelf, created_at: 8.months.ago)
+    10.times { |i| @user.books.create!(title: "Fresh Book #{i}", shelf: shelves(:one)) }
+
+    get root_url
+
+    assert_match "Dusty Archive", response.body
+    assert_no_match "Forgotten Tome", response.body
   end
 
   test "requires authentication" do

--- a/test/models/library_dashboard_test.rb
+++ b/test/models/library_dashboard_test.rb
@@ -44,42 +44,74 @@ class LibraryDashboardTest < ActiveSupport::TestCase
     assert_equal 2, @dashboard.top_genres(limit: 2).length
   end
 
-  test "recently_updated returns newest first with a limit" do
-    oldest = @user.books.create!(title: "Oldest", shelf: @scifi_shelf)
-    newest = @user.books.create!(title: "Newest", shelf: @scifi_shelf)
-    oldest.update!(updated_at: 2.days.ago)
-    newest.update!(updated_at: 1.minute.ago)
+  test "recently_added returns newest additions first with a limit" do
+    oldest = @user.books.create!(title: "Oldest", shelf: @scifi_shelf, created_at: 2.days.ago)
+    newest = @user.books.create!(title: "Newest", shelf: @scifi_shelf, created_at: 1.minute.ago)
+    oldest.update!(updated_at: Time.current)
 
-    assert_equal [newest, oldest], @dashboard.recently_updated
-    assert_equal [newest], @dashboard.recently_updated(limit: 1)
+    assert_equal [newest, oldest], @dashboard.recently_added
+    assert_equal [newest], @dashboard.recently_added(limit: 1)
   end
 
-  test "shelves_with_recent_books returns each shelf with its newest books" do
-    old_book = @user.books.create!(title: "Old Scifi", shelf: @scifi_shelf, created_at: 2.days.ago)
-    new_book = @user.books.create!(title: "New Scifi", shelf: @scifi_shelf, created_at: 1.minute.ago)
-    biz_book = @user.books.create!(title: "Biz", shelf: @biz_shelf)
+  test "currently_reading finds the in-progress shelf by name" do
+    reading_shelf = Shelf.create!(name: "📖 In Progress", user: @user)
+    book = @user.books.create!(title: "Current Read", shelf: reading_shelf)
 
-    result = @dashboard.shelves_with_recent_books
+    shelf, books = @dashboard.currently_reading
 
-    assert_equal 2, result.length
-
-    scifi_entry = result.find { |shelf, _books| shelf == @scifi_shelf }
-
-    assert_equal [new_book, old_book], scifi_entry.last
-
-    biz_entry = result.find { |shelf, _books| shelf == @biz_shelf }
-
-    assert_equal [biz_book], biz_entry.last
+    assert_equal reading_shelf, shelf
+    assert_equal [book], books
   end
 
-  test "shelves_with_recent_books limits books per shelf and orders shelves by book count" do
-    3.times { |i| @user.books.create!(title: "Scifi #{i}", shelf: @scifi_shelf) }
-    @user.books.create!(title: "Biz", shelf: @biz_shelf)
+  test "currently_reading is nil when no in-progress shelf exists" do
+    assert_nil @dashboard.currently_reading
+  end
 
-    result = @dashboard.shelves_with_recent_books(limit: 2)
+  test "shelf_summaries orders shelves by most recent addition with newest books" do
+    @user.books.create!(title: "Old Scifi", shelf: @scifi_shelf, created_at: 3.days.ago)
+    @user.books.create!(title: "Biz", shelf: @biz_shelf, created_at: 2.days.ago)
+    newest = @user.books.create!(title: "New Scifi", shelf: @scifi_shelf, created_at: 1.minute.ago)
 
-    assert_equal @scifi_shelf, result.first.first
-    assert_equal 2, result.first.last.length
+    result = @dashboard.shelf_summaries
+
+    assert_equal [@scifi_shelf, @biz_shelf], result.map(&:shelf)
+    assert_equal newest, result.first.recent_books.first
+    assert_equal 2, result.first.book_count
+  end
+
+  test "shelf_summaries limits recent books per shelf" do
+    5.times { |i| @user.books.create!(title: "Scifi #{i}", shelf: @scifi_shelf) }
+
+    result = @dashboard.shelf_summaries(recent_limit: 3)
+
+    assert_equal 3, result.first.recent_books.length
+    assert_equal 5, result.first.book_count
+  end
+
+  test "shelf_summaries collapses inactive shelves to count-only" do
+    @user.books.create!(title: "Dusty", shelf: @biz_shelf, created_at: 7.months.ago)
+    @user.books.create!(title: "Fresh", shelf: @scifi_shelf)
+
+    result = @dashboard.shelf_summaries
+
+    biz_summary = result.find { |s| s.shelf == @biz_shelf }
+
+    assert_empty biz_summary.recent_books
+    assert_equal 1, biz_summary.book_count
+
+    scifi_summary = result.find { |s| s.shelf == @scifi_shelf }
+
+    assert_not_empty scifi_summary.recent_books
+  end
+
+  test "shelf_summaries excludes the currently-reading shelf and empty shelves" do
+    reading_shelf = Shelf.create!(name: "📖 In Progress", user: @user)
+    @user.books.create!(title: "Current Read", shelf: reading_shelf)
+    @user.books.create!(title: "Fresh", shelf: @scifi_shelf)
+
+    result = @dashboard.shelf_summaries
+
+    assert_equal [@scifi_shelf], result.map(&:shelf)
   end
 
   test "handles an empty library" do
@@ -88,7 +120,8 @@ class LibraryDashboardTest < ActiveSupport::TestCase
 
     assert_equal 0, dashboard.book_count
     assert_empty dashboard.top_genres
-    assert_empty dashboard.recently_updated
-    assert_empty dashboard.shelves_with_recent_books
+    assert_empty dashboard.recently_added
+    assert_empty dashboard.shelf_summaries
+    assert_nil dashboard.currently_reading
   end
 end


### PR DESCRIPTION
## Summary

Implements the homepage layout agreed in review of the v1 dashboard (BOOK-13). Keeps what worked (stat tiles, top genres), fixes what didn't:

- **"Recently updated" → "Recently added"** — `updated_at` was rendered meaningless by the genre backfill (and any future bulk op); `created_at` is immune and answers the better question.
- **📖 In Progress hero row** — cover images for the books being read now, right under the genre badges. The shelf is found by name (`/in progress/i`) — a documented, pragmatic heuristic until read status is first-class data (ROADMAP Priority 2).
- **Tiered shelves** — every other shelf shows its **3 newest** books, ordered by most-recent addition rather than size, so active shelves float up naturally. Shelves with nothing added in 6 months collapse into a single count-only "Quieter shelves" card. Empty shelves stay hidden; the hero shelf isn't repeated.
- **Clickable stat tiles** — Books → `/books`, Shelves → `/shelves`, Fiction/Nonfiction → pre-filtered search (matching the genre badges' behavior).

## Real-data verification

Rendered against a copy of the production DB: hero picks up 📖 In Progress (3 books, covers render), active cards are 📚 To Read (448), ⭐ Short List (26), 👍 Liked (316), and 9 archive shelves collapse to count rows. Page weight dropped from ~24KB to ~12.6KB.

## Testing

TDD: `LibraryDashboard` tests for `recently_added`, `currently_reading` (found/absent), `shelf_summaries` (activity ordering, 3-book limit, inactive collapse, hero exclusion, empty-shelf hiding); controller tests for the hero, the added/updated swap, and the count-only collapse. Full suite: 121 runs, 257 assertions, 0 failures. Rubocop clean.

Related: BOOK-12 / #30 (v1), BOOK-11 (data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)